### PR TITLE
Added ruby-devel as dependency

### DIFF
--- a/ansible/roles/virtualization/tasks/main.yml
+++ b/ansible/roles/virtualization/tasks/main.yml
@@ -15,6 +15,7 @@
       - libxslt-devel
       - libxml2-devel
       - pkg-config
+      - ruby-devel
   notify: restart libvirt
 
 - name: add user to libvirt group


### PR DESCRIPTION
Vagrant-libvirt needs ruby-devel to work now.